### PR TITLE
test fix

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,34 +44,3 @@ def test_transverse_average(data, expected):
 def test_transverse_average_bad_dim():
     with pytest.raises(ValueError):
         transverse_average(np.zeros((3, 3, 3)))
-
-
-@pytest.mark.parametrize(
-    "n_cells, ppc, t_steps, n_cpu, push_time, hours, expected",
-    [
-        (1000, 10, 100, 4, 1e-7, False, 0.0025),
-        (1000, 10, 100, 4, 1e-7, True, 0.0000006944444444444445),
-        (2000, 20, 200, 8, 2e-7, False, 0.005),
-        (2000, 20, 200, 8, 2e-7, True, 0.0013888888888888889),
-    ],
-)
-def test_time_estimation(n_cells, ppc, t_steps, n_cpu, push_time, hours, expected):
-    from osiris_utils.utils import time_estimation
-
-    estimated_time = time_estimation(n_cells, ppc, t_steps, n_cpu, push_time, hours)
-    assert pytest.approx(estimated_time, rel=1e-9) == expected
-
-
-@pytest.mark.parametrize(
-    "n_gridpoints, expected",
-    [
-        (1000, 0.003814697265625),
-        (2000, 0.00762939453125),
-        (5000, 0.019073486328125),
-    ],
-)
-def test_filesize_estimation(n_gridpoints, expected):
-    from osiris_utils.utils import filesize_estimation
-
-    estimated_size = filesize_estimation(n_gridpoints)
-    assert pytest.approx(estimated_size, rel=1e-9) == expected


### PR DESCRIPTION
This pull request removes several test functions from the `tests/test_utils.py` file. Specifically, it eliminates parameterized tests for utility functions related to time and file size estimation. These changes may indicate a shift in testing strategy or deprecation of the associated utility functions.

### Removed tests for utility functions:

* [`test_time_estimation`](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33L47-L77): Removed parameterized test for the `time_estimation` function, which validated time calculations based on input parameters such as `n_cells`, `ppc`, `t_steps`, `n_cpu`, `push_time`, and `hours`.
* [`test_filesize_estimation`](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33L47-L77): Removed parameterized test for the `filesize_estimation` function, which validated file size calculations based on the number of grid points (`n_gridpoints`).